### PR TITLE
upgrade to go 1.17.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.2-bullseye
+FROM golang:1.17.6-bullseye
 
 ENV GOPATH=/tmp/gotools
 ENV GO111MODULE=on


### PR DESCRIPTION
This is due to https://nvd.nist.gov/vuln/detail/CVE-2021-44716

I intend to release a v0.6.0 of this image after this is merged and upgrade all Go-based @brigadecore projects to use that.