### PR TITLE
remove packr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV GO111MODULE=on
 
 RUN go get -v \
     golang.org/x/tools/cmd/goimports@release-branch.go1.15 \
-    github.com/gobuffalo/packr/v2/packr2@v2.8.1 \
     #
     # Install Go tools
     && mv $GOPATH/bin/* /usr/local/bin/ \


### PR DESCRIPTION
We've always included packr in our go-tools and have never, ever used it. Let's drop it.