### PR TITLE
add ghr to our go-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.18.0-bullseye
 
 ARG GOLANGCI_LINT_VERSION=v1.45.0
+ARG GHR_VERSION=v0.14.0
 
     # Install golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin $GOLANGCI_LINT_VERSION \
+    # Install ghr from source (there is no prebuilt binary for arm64)
+    && go install github.com/tcnksm/ghr@$GHR_VERSION \
     # Install codecov
     && curl -o /usr/local/bin/codecov https://uploader.codecov.io/v0.1.0_8880/linux/codecov \
     && chmod 755 /usr/local/bin/codecov


### PR DESCRIPTION
In the main repo's release process, we use `ghr` to publish pre-built `brig` binaries. That step failed for the `v2.4.0-rc.1` release because we have, until now, been installing `ghr` just-in-time using `go get` and Go 1.18 no longer allows `go get` to be used outside the context of a module. `go install` is to be used instead.

That failure presents an opportunity for improvement...

It seems pretty reasonable to me to do the `go install` of `ghr` here and bake it into our `go-tools` image instead of always installing it just-in-time during the release process.