### PR TITLE
add secrets template

### DIFF
--- a/.brigade/secrets-template.yaml
+++ b/.brigade/secrets-template.yaml
@@ -1,0 +1,42 @@
+## We ALWAYS log into Docker Hub to avoid being rate limited on pulls in FROM
+## directives of our Dockerfiles.
+dockerhubUsername: brigadecoreci
+dockerhubPassword: "<Placeholder>"
+
+## If unstableImageRegistry is unspecified, Docker Hub will be used.
+unstableImageRegistry: unstablebrigade.azurecr.io
+
+## unstableImageRegistryOrg is optional if the unstable image registry does not
+## require it. Docker Hub, for instance DOES.
+# unstableImageRegistryOrg: ""
+
+## unstableImageRegistryUsername and unstableImageRegistryPassword are optional
+## if the unstable image registry is Docker Hub (which we already
+## unconditionally login into) or if the unstable image registry is a private
+## one that doesn't require authentication.
+unstableImageRegistryUsername: unstablebrigade
+unstableImageRegistryPassword: "<Placeholder>"
+
+## If stableImageRegistry is unspecified, Docker Hub will be used.
+# stableImageRegistry: ""
+
+## stableImageRegistryOrg is optional if the stable image registry does not
+## require it. Docker Hub, for instance, DOES.
+stableImageRegistryOrg: brigadecore
+
+## The stable image registry should always be a public registry, so we assume we
+## MUST authenticate.
+stableImageRegistryUsername: brigadecoreci
+stableImageRegistryPassword: "<Placeholder>"
+
+## Base64-encoded key used for signing images pushed to the stable registry.
+## This key belongs to the same user specified by stableImageRegistryUsername.
+imageSigningKeyHash: 2f41aa6fd9326a09eea76bfce528908b271a82f2c387a26fca2d3f3925b9b2e2
+base64ImageSigningKey: "<Placeholder>"
+imageSigningKeyPassphrase: "<Placeholder>"
+
+## The following are required for publishing the SBOM to the GitHub releases
+## page.
+githubOrg: brigadecore
+githubRepo: go-tools
+githubToken: "<Placeholder>"


### PR DESCRIPTION
To aid in setting this project up as quickly as possible in the future, this PR adds a "template" for a `secrets.yaml` file that redacts sensitive values, but retains a few non-sensitive values and numerous comments. This should provide helpful context to future maintainers who want to use Brigade to build this project.